### PR TITLE
uclient-fetch强制使用ipv4解析

### DIFF
--- a/root/usr/share/unblockneteasemusic/update.sh
+++ b/root/usr/share/unblockneteasemusic/update.sh
@@ -19,7 +19,7 @@ clean_log(){
 }
 
 check_core_latest_version() {
-	core_latest_ver="$(uclient-fetch -qO- 'https://api.github.com/repos/UnblockNeteaseMusic/server/commits?sha=enhanced&path=precompiled' | jsonfilter -e '@[0].sha')"
+	core_latest_ver="$(uclient-fetch -4qO- 'https://api.github.com/repos/UnblockNeteaseMusic/server/commits?sha=enhanced&path=precompiled' | jsonfilter -e '@[0].sha')"
 	[ -n "${core_latest_ver}" ] || { echo -e "\nFailed to check latest core version, please try again later." >> "/tmp/$NAME.log"; rm -f "$LOCK"; exit 1; }
 	if [ ! -e "/usr/share/$NAME/core_local_ver" ]; then
 		clean_log
@@ -45,9 +45,9 @@ update_core() {
 	mkdir -p "/usr/share/$NAME/core"
 	rm -rf "/usr/share/$NAME/core"/*
 
-	for url in $(uclient-fetch -qO- "https://api.github.com/repos/UnblockNeteaseMusic/server/contents/precompiled" |jsonfilter -e '@[*].download_url')
+	for url in $(uclient-fetch -4qO- "https://api.github.com/repos/UnblockNeteaseMusic/server/contents/precompiled" |jsonfilter -e '@[*].download_url')
 	do
-		uclient-fetch "${url}" -qO "/usr/share/$NAME/core/${url##*/}"
+		uclient-fetch "${url}" -4qO "/usr/share/$NAME/core/${url##*/}"
 		[ -s "/usr/share/$NAME/core/${url##*/}" ] || {
 			echo -e "Failed to download ${url##*/}." >> "/tmp/$NAME.log"
 			rm -f "$LOCK"
@@ -57,7 +57,7 @@ update_core() {
 
 	for cert in "ca.crt" "server.crt" "server.key"
 	do
-		uclient-fetch "https://raw.githubusercontent.com/UnblockNeteaseMusic/server/enhanced/${cert}" -qO "/usr/share/$NAME/core/${cert}"
+		uclient-fetch "https://raw.githubusercontent.com/UnblockNeteaseMusic/server/enhanced/${cert}" -4qO "/usr/share/$NAME/core/${cert}"
 		[ -s "/usr/share/$NAME/core/${cert}" ] || {
 			echo -e "Failed to download ${cert}." >> "/tmp/$NAME.log"
 			rm -f "$LOCK"


### PR DESCRIPTION
由于uclient-fetch默认优先使用ipv6解析，目前ipv6会出现莫名其妙的的问题在开启ipv6的情况下可能会dns解析失败。 #143
故在uclient-fetch参数项加入-4强行使用ipv4进行域名解析 